### PR TITLE
fix shortcut view disappear when long click on item

### DIFF
--- a/src/com/android/launcher3/dragndrop/DragController.java
+++ b/src/com/android/launcher3/dragndrop/DragController.java
@@ -634,7 +634,9 @@ public class DragController implements DragDriver.EventListener, TouchController
             case MotionEvent.ACTION_MOVE:
                 if(dragLayerX != ev.getX() &&
                         dragLayerY != ev.getY()){
-                    if(Launcher.getShortcutsCreation() != null) {
+                    int deltaX = (int)Math.abs(mMotionDownX - ev.getX());
+                    int deltaY = (int)Math.abs(mMotionDownY - ev.getY());
+                    if(Launcher.getShortcutsCreation() != null && (deltaX > 1 || deltaY > 1)) {
                         Launcher.getShortcutsCreation().clearAllLayout();
                     }
                     Hotseat.isHotseatTouched = false;


### PR DESCRIPTION
Hi: 
    When I compile this launcher and pushed into my phone, I found the Shortcuts view often disappear when I long click on an item.
    After reading the code, I think the root cause is because the DragController receive a TouchEvent with ACTION_MOVE type, and in its onTouchEvent callback call ShortcutsCreation.clearAllLayout().
Maybe this is only happening on my phone, but I think do some movement checking is helpful.